### PR TITLE
chore(package): move Vite from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "type": "git",
     "url": "git+https://github.com/XeicuLy/eslint-plugin-reactive-value-suffix"
   },
-  "dependencies": {
-    "vite": "^5.4.5"
-  },
   "devDependencies": {
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
@@ -64,6 +61,7 @@
     "semantic-release": "^24.1.1",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.5.0",
+    "vite": "^5.4.6",
     "vite-tsconfig-paths": "^5.0.1",
     "vitest": "^2.1.1"
   },


### PR DESCRIPTION
Since `vite` is only required in the development environment, I moved it to `devDependencies`

close #12