### PR TITLE
Improve test coverage

### DIFF
--- a/src/rules/helpers/astHelpers.ts
+++ b/src/rules/helpers/astHelpers.ts
@@ -25,7 +25,7 @@ const { AST_NODE_TYPES } = TSESTree;
  * @param {ASTNodeType} type Node type (e.g., Identifier, ObjectPattern, etc.)
  * @returns {node is T} Whether it matches the specified type
  */
-function isNodeOfType<T extends Node>(node: Node | undefined | null, type: ASTNodeType): node is T {
+export function isNodeOfType<T extends Node>(node: Node | undefined | null, type: ASTNodeType): node is T {
   return node !== undefined && node !== null && node.type === type;
 }
 
@@ -176,7 +176,11 @@ export function isArgumentOfFunction(node: Identifier, ignoredFunctionNames: str
   }
 
   const isMatchingName = isMatchingFunctionName(callExpression.callee.name, ignoredFunctionNames);
-  return isMatchingName && callExpression.arguments.includes(node);
+  const isArgument = callExpression.arguments.some(
+    (argument) => isIdentifier(argument) && argument.type === node.type && argument.name === node.name,
+  );
+
+  return isMatchingName && isArgument;
 }
 
 /**
@@ -214,7 +218,7 @@ export function isWatchArgument(node: Identifier): boolean {
  * @param {string[]} functionNames List of function names to check
  * @returns {boolean} Whether it is a function call
  */
-function isFunctionCall(node: VariableDeclarator, functionNames: string[]): boolean {
+export function isFunctionCall(node: VariableDeclarator, functionNames: string[]): boolean {
   return (
     isCallExpression(node.init) && isIdentifier(node.init.callee) && functionNames.includes(node.init.callee?.name)
   );
@@ -295,6 +299,6 @@ export function isDestructuredFunctionArgument(
  * @param {string[]} destructuredFunctions List of destructured functions
  * @returns {boolean} Whether the node is a destructured function call
  */
-function isNodeDestructuredFunction(node: Node, destructuredFunctions: string[]): boolean {
+export function isNodeDestructuredFunction(node: Node, destructuredFunctions: string[]): boolean {
   return isCallExpression(node) && isIdentifier(node.callee) && destructuredFunctions.includes(node.callee.name);
 }

--- a/test/rules/helpers/astHelpers.spec.ts
+++ b/test/rules/helpers/astHelpers.spec.ts
@@ -892,6 +892,8 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
   describe('isDestructuredFunctionArgument', () => {
     const destructuredFunctions = ['useFetch', 'useData'];
+    let parent: TSESTree.CallExpression;
+    let grandParent: TSESTree.CallExpression | undefined;
 
     beforeEach(() => {
       vi.spyOn(astHelpers, 'isNodeDestructuredFunction').mockImplementation((node, functions) =>
@@ -900,22 +902,22 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     });
 
     it('should return true if the parent is a destructured function', () => {
-      const parent = {
+      parent = {
         type: CallExpression,
         callee: { type: Identifier, name: 'useFetch' },
       } as TSESTree.CallExpression;
-      const grandParent = undefined;
+      grandParent = undefined;
 
       const result = isDestructuredFunctionArgument(parent, grandParent, destructuredFunctions);
       expect(result).toBe(true);
     });
 
     it('should return true if the grandParent is a destructured function', () => {
-      const parent = {
+      parent = {
         type: CallExpression,
         callee: { type: Identifier, name: 'fetchData' },
       } as TSESTree.CallExpression;
-      const grandParent = {
+      grandParent = {
         type: CallExpression,
         callee: { type: Identifier, name: 'useData' },
       } as TSESTree.CallExpression;
@@ -925,11 +927,11 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     });
 
     it('should return false if neither parent nor grandParent is a destructured function', () => {
-      const parent = {
+      parent = {
         type: CallExpression,
         callee: { type: Identifier, name: 'fetchData' },
       } as TSESTree.CallExpression;
-      const grandParent = {
+      grandParent = {
         type: CallExpression,
         callee: { type: Identifier, name: 'otherFunction' },
       } as TSESTree.CallExpression;

--- a/test/rules/helpers/astHelpers.spec.ts
+++ b/test/rules/helpers/astHelpers.spec.ts
@@ -26,6 +26,7 @@ const {
   isObjectKey,
   isOriginalDeclaration,
   isNodeDestructuredFunction,
+  isDestructuredFunctionArgument,
 } = astHelpers;
 
 const {
@@ -886,6 +887,55 @@ describe('src/rules/helpers/astHelpers.ts', () => {
         const result = isNodeDestructuredFunction(node as TSESTree.Node, destructuredFunctions);
         expect(result).toBe(expected);
       });
+    });
+  });
+
+  describe('isDestructuredFunctionArgument', () => {
+    const destructuredFunctions = ['useFetch', 'useData'];
+
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isNodeDestructuredFunction').mockImplementation((node, functions) =>
+        functions.includes((node as TSESTree.Identifier).name),
+      );
+    });
+
+    it('should return true if the parent is a destructured function', () => {
+      const parent = {
+        type: CallExpression,
+        callee: { type: Identifier, name: 'useFetch' },
+      } as TSESTree.CallExpression;
+      const grandParent = undefined;
+
+      const result = isDestructuredFunctionArgument(parent, grandParent, destructuredFunctions);
+      expect(result).toBe(true);
+    });
+
+    it('should return true if the grandParent is a destructured function', () => {
+      const parent = {
+        type: CallExpression,
+        callee: { type: Identifier, name: 'fetchData' },
+      } as TSESTree.CallExpression;
+      const grandParent = {
+        type: CallExpression,
+        callee: { type: Identifier, name: 'useData' },
+      } as TSESTree.CallExpression;
+
+      const result = isDestructuredFunctionArgument(parent, grandParent, destructuredFunctions);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if neither parent nor grandParent is a destructured function', () => {
+      const parent = {
+        type: CallExpression,
+        callee: { type: Identifier, name: 'fetchData' },
+      } as TSESTree.CallExpression;
+      const grandParent = {
+        type: CallExpression,
+        callee: { type: Identifier, name: 'otherFunction' },
+      } as TSESTree.CallExpression;
+
+      const result = isDestructuredFunctionArgument(parent, grandParent, destructuredFunctions);
+      expect(result).toBe(false);
     });
   });
 });

--- a/test/rules/helpers/astHelpers.spec.ts
+++ b/test/rules/helpers/astHelpers.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
+import { TSESTree } from '@typescript-eslint/utils';
+import * as astHelpers from '@/rules/helpers/astHelpers';
+
+const {
   isNodeOfType,
   isIdentifier,
   isObjectPattern,
@@ -23,9 +26,7 @@ import {
   isObjectKey,
   isOriginalDeclaration,
   isNodeDestructuredFunction,
-} from '@/rules/helpers/astHelpers';
-import { TSESTree } from '@typescript-eslint/utils';
-import * as astHelpers from '@/rules/helpers/astHelpers';
+} = astHelpers;
 
 const {
   Identifier,

--- a/test/rules/helpers/astHelpers.spec.ts
+++ b/test/rules/helpers/astHelpers.spec.ts
@@ -41,6 +41,7 @@ const {
   BlockStatement,
   ArrowFunctionExpression,
   Literal,
+  ExpressionStatement,
 } = TSESTree.AST_NODE_TYPES;
 
 afterEach(() => {
@@ -487,7 +488,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
         type: CallExpression,
         callee: { type: Identifier, name: 'someFunction' },
         arguments: [{ type: Identifier, name: 'arg1' }],
-      } as unknown as TSESTree.CallExpression;
+      } as TSESTree.CallExpression;
 
       vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
       vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
@@ -546,7 +547,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
         type: CallExpression,
         callee: { type: Literal, value: 'nonIdentifier' },
         arguments: [node],
-      } as unknown as TSESTree.CallExpression;
+      } as TSESTree.CallExpression;
 
       vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
       vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
@@ -562,7 +563,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
         type: CallExpression,
         callee: { type: Identifier, name: 'differentFunction' },
         arguments: [node],
-      } as unknown as TSESTree.CallExpression;
+      } as TSESTree.CallExpression;
 
       vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
       vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
@@ -627,7 +628,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       const arrayExpression = {
         type: ArrayExpression,
         elements: [node],
-      } as unknown as TSESTree.ArrayExpression;
+      } as TSESTree.ArrayExpression;
 
       const callExpression = node.parent as TSESTree.CallExpression;
       callExpression.arguments.push(arrayExpression);
@@ -660,7 +661,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       const callExpression = {
         ...node.parent,
         callee: { type: Identifier, name: 'notWatch' },
-      } as unknown as TSESTree.CallExpression;
+      } as TSESTree.CallExpression;
 
       vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
       vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
@@ -699,12 +700,12 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return true if node.init is a call expression and callee is in the function names list', () => {
       const node = {
-        type: 'VariableDeclarator',
+        type: VariableDeclarator,
         init: {
-          type: 'CallExpression',
-          callee: { type: 'Identifier', name: 'myFunction' },
+          type: CallExpression,
+          callee: { type: Identifier, name: 'myFunction' },
         },
-      } as unknown as TSESTree.VariableDeclarator;
+      } as TSESTree.VariableDeclarator;
 
       const functionNames = ['myFunction'];
       const result = isFunctionCall(node, functionNames);
@@ -715,12 +716,12 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       vi.spyOn(astHelpers, 'isCallExpression').mockReturnValue(false);
 
       const node = {
-        type: 'VariableDeclarator',
+        type: VariableDeclarator,
         init: {
           type: Literal,
           value: 'someValue',
         },
-      } as unknown as TSESTree.VariableDeclarator;
+      } as TSESTree.VariableDeclarator;
 
       const functionNames = ['myFunction'];
       const result = isFunctionCall(node, functionNames);
@@ -731,12 +732,12 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
 
       const node = {
-        type: 'VariableDeclarator',
+        type: VariableDeclarator,
         init: {
-          type: 'CallExpression',
+          type: CallExpression,
           callee: { type: Literal, value: 'someValue' },
         },
-      } as unknown as TSESTree.VariableDeclarator;
+      } as TSESTree.VariableDeclarator;
 
       const functionNames = ['myFunction'];
       const result = isFunctionCall(node, functionNames);
@@ -745,12 +746,12 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return false if callee name is not in the function names list', () => {
       const node = {
-        type: 'VariableDeclarator',
+        type: VariableDeclarator,
         init: {
-          type: 'CallExpression',
-          callee: { type: 'Identifier', name: 'otherFunction' },
+          type: CallExpression,
+          callee: { type: Identifier, name: 'otherFunction' },
         },
-      } as unknown as TSESTree.VariableDeclarator;
+      } as TSESTree.VariableDeclarator;
 
       const functionNames = ['myFunction'];
       const result = isFunctionCall(node, functionNames);
@@ -765,33 +766,33 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return the first CallExpression node when found', () => {
       const node = {
-        type: 'Identifier',
+        type: Identifier,
         parent: {
-          type: 'ExpressionStatement',
+          type: ExpressionStatement,
           parent: {
-            type: 'CallExpression',
-            callee: { type: 'Identifier', name: 'myFunction' },
+            type: CallExpression,
+            callee: { type: Identifier, name: 'myFunction' },
           },
         },
-      } as unknown as TSESTree.Node;
+      } as TSESTree.Node;
 
       const result = getAncestorCallExpression(node);
       expect(result).toEqual({
-        type: 'CallExpression',
-        callee: { type: 'Identifier', name: 'myFunction' },
+        type: CallExpression,
+        callee: { type: Identifier, name: 'myFunction' },
       });
     });
 
     it('should return null if no CallExpression is found', () => {
       const node = {
-        type: 'Identifier',
+        type: Identifier,
         parent: {
-          type: 'ExpressionStatement',
+          type: ExpressionStatement,
           parent: {
-            type: 'BlockStatement',
+            type: BlockStatement,
           },
         },
-      } as unknown as TSESTree.Node;
+      } as TSESTree.Node;
 
       const result = getAncestorCallExpression(node);
       expect(result).toBeNull();
@@ -799,7 +800,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return null if the node has no parent', () => {
       const node = {
-        type: 'Identifier',
+        type: Identifier,
         parent: null,
       } as unknown as TSESTree.Node;
 
@@ -809,8 +810,8 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return null if there are no ancestors', () => {
       const node = {
-        type: 'Identifier',
-      } as unknown as TSESTree.Node;
+        type: Identifier,
+      } as TSESTree.Node;
 
       const result = getAncestorCallExpression(node);
       expect(result).toBeNull();
@@ -819,8 +820,8 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
   describe('isPropertyValue', () => {
     beforeEach(() => {
-      vi.spyOn(astHelpers, 'isMemberExpression').mockImplementation((node) => node?.type === 'MemberExpression');
-      vi.spyOn(astHelpers, 'isIdentifier').mockImplementation((node) => node?.type === 'Identifier');
+      vi.spyOn(astHelpers, 'isMemberExpression').mockImplementation((node) => node?.type === MemberExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockImplementation((node) => node?.type === Identifier);
     });
 
     afterEach(() => {
@@ -829,10 +830,10 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return true when the node is a MemberExpression with property name "value"', () => {
       const node = {
-        type: 'MemberExpression',
-        object: { type: 'Identifier', name: 'refValue' },
-        property: { type: 'Identifier', name: 'value' },
-      } as unknown as TSESTree.Node;
+        type: MemberExpression,
+        object: { type: Identifier, name: 'refValue' },
+        property: { type: Identifier, name: 'value' },
+      } as TSESTree.Node;
 
       const result = isPropertyValue(node);
       expect(result).toBe(true);
@@ -842,7 +843,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       const node = {
         type: Literal,
         value: 123,
-      } as unknown as TSESTree.Node;
+      } as TSESTree.Node;
 
       const result = isPropertyValue(node);
       expect(result).toBe(false);
@@ -850,10 +851,10 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return false when the property is not an Identifier', () => {
       const node = {
-        type: 'MemberExpression',
-        object: { type: 'Identifier', name: 'refValue' },
+        type: MemberExpression,
+        object: { type: Identifier, name: 'refValue' },
         property: { type: Literal, value: 'value' },
-      } as unknown as TSESTree.Node;
+      } as TSESTree.Node;
 
       const result = isPropertyValue(node);
       expect(result).toBe(false);
@@ -861,10 +862,10 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return false when the property name is not "value"', () => {
       const node = {
-        type: 'MemberExpression',
-        object: { type: 'Identifier', name: 'refValue' },
-        property: { type: 'Identifier', name: 'notValue' },
-      } as unknown as TSESTree.Node;
+        type: MemberExpression,
+        object: { type: Identifier, name: 'refValue' },
+        property: { type: Identifier, name: 'notValue' },
+      } as TSESTree.Node;
 
       const result = isPropertyValue(node);
       expect(result).toBe(false);
@@ -873,7 +874,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
   describe('isFunctionArgument', () => {
     it('should return true if the node name is in the function arguments list', () => {
-      const node = { type: 'Identifier', name: 'arg1' } as TSESTree.Identifier;
+      const node = { type: Identifier, name: 'arg1' } as TSESTree.Identifier;
       const functionArguments = ['arg1', 'arg2'];
 
       const result = isFunctionArgument(node, functionArguments);
@@ -881,7 +882,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     });
 
     it('should return false if the node name is not in the function arguments list', () => {
-      const node = { type: 'Identifier', name: 'arg3' } as TSESTree.Identifier;
+      const node = { type: Identifier, name: 'arg3' } as TSESTree.Identifier;
       const functionArguments = ['arg1', 'arg2'];
 
       const result = isFunctionArgument(node, functionArguments);
@@ -889,7 +890,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     });
 
     it('should return false if the function arguments list is empty', () => {
-      const node = { type: 'Identifier', name: 'arg1' } as TSESTree.Identifier;
+      const node = { type: Identifier, name: 'arg1' } as TSESTree.Identifier;
       const functionArguments: string[] = [];
 
       const result = isFunctionArgument(node, functionArguments);
@@ -897,7 +898,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     });
 
     it('should return true if the node name matches exactly in the function arguments list', () => {
-      const node = { type: 'Identifier', name: 'arg' } as TSESTree.Identifier;
+      const node = { type: Identifier, name: 'arg' } as TSESTree.Identifier;
       const functionArguments = ['arg'];
 
       const result = isFunctionArgument(node, functionArguments);
@@ -905,7 +906,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     });
 
     it('should return false if the node name partially matches any of the function arguments', () => {
-      const node = { type: 'Identifier', name: 'arg' } as TSESTree.Identifier;
+      const node = { type: Identifier, name: 'arg' } as TSESTree.Identifier;
       const functionArguments = ['argument'];
 
       const result = isFunctionArgument(node, functionArguments);
@@ -925,11 +926,11 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return true if the node is a property and the key matches the identifier name', () => {
       const node = {
-        type: 'Property',
-        key: { type: 'Identifier', name: 'key1' },
+        type: Property,
+        key: { type: Identifier, name: 'key1' },
       } as TSESTree.Property;
 
-      const identifierNode = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
+      const identifierNode = { type: Identifier, name: 'key1' } as TSESTree.Identifier;
 
       const result = isObjectKey(node, identifierNode);
       expect(result).toBe(true);
@@ -938,8 +939,8 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     it('should return false if the node is not a property', () => {
       vi.spyOn(astHelpers, 'isProperty').mockReturnValue(false);
 
-      const node = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
-      const identifierNode = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
+      const node = { type: Identifier, name: 'key1' } as TSESTree.Identifier;
+      const identifierNode = { type: Identifier, name: 'key1' } as TSESTree.Identifier;
 
       const result = isObjectKey(node, identifierNode);
       expect(result).toBe(false);
@@ -949,11 +950,11 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
 
       const node = {
-        type: 'Property',
+        type: Property,
         key: { type: Literal, value: 'key1' },
-      } as unknown as TSESTree.Property;
+      } as TSESTree.Property;
 
-      const identifierNode = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
+      const identifierNode = { type: Identifier, name: 'key1' } as TSESTree.Identifier;
 
       const result = isObjectKey(node, identifierNode);
       expect(result).toBe(false);
@@ -961,11 +962,11 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return false if the node key does not match the identifier name', () => {
       const node = {
-        type: 'Property',
-        key: { type: 'Identifier', name: 'key1' },
+        type: Property,
+        key: { type: Identifier, name: 'key1' },
       } as TSESTree.Property;
 
-      const identifierNode = { type: 'Identifier', name: 'key2' } as TSESTree.Identifier;
+      const identifierNode = { type: Identifier, name: 'key2' } as TSESTree.Identifier;
 
       const result = isObjectKey(node, identifierNode);
       expect(result).toBe(false);
@@ -985,7 +986,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     it('should return true if the node is a MemberExpression', () => {
       vi.spyOn(astHelpers, 'isMemberExpression').mockReturnValue(true);
 
-      const node = { type: 'MemberExpression' } as TSESTree.MemberExpression;
+      const node = { type: MemberExpression } as TSESTree.MemberExpression;
 
       const result = isOriginalDeclaration(node);
       expect(result).toBe(true);
@@ -994,7 +995,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     it('should return true if the node is a Property', () => {
       vi.spyOn(astHelpers, 'isProperty').mockReturnValue(true);
 
-      const node = { type: 'Property' } as TSESTree.Property;
+      const node = { type: Property } as TSESTree.Property;
 
       const result = isOriginalDeclaration(node);
       expect(result).toBe(true);
@@ -1004,7 +1005,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       vi.spyOn(astHelpers, 'isMemberExpression').mockReturnValue(false);
       vi.spyOn(astHelpers, 'isProperty').mockReturnValue(false);
 
-      const node = { type: 'Identifier' } as TSESTree.Identifier;
+      const node = { type: Identifier } as TSESTree.Identifier;
 
       const result = isOriginalDeclaration(node);
       expect(result).toBe(false);
@@ -1014,9 +1015,9 @@ describe('src/rules/helpers/astHelpers.ts', () => {
   describe('isNodeDestructuredFunction', () => {
     it('should return true if the node is a destructured function call', () => {
       const node = {
-        type: 'CallExpression',
-        callee: { type: 'Identifier', name: 'useFetch' },
-      } as unknown as TSESTree.Node;
+        type: CallExpression,
+        callee: { type: Identifier, name: 'useFetch' },
+      } as TSESTree.Node;
 
       const destructuredFunctions = ['useFetch'];
 
@@ -1027,8 +1028,8 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return false if the node is not a CallExpression', () => {
       const node = {
-        type: 'Identifier',
-        callee: { type: 'Identifier', name: 'useFetch' },
+        type: Identifier,
+        callee: { type: Identifier, name: 'useFetch' },
       } as unknown as TSESTree.Node;
 
       const destructuredFunctions = ['useFetch'];
@@ -1040,9 +1041,9 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return false if the callee is not an Identifier', () => {
       const node = {
-        type: 'CallExpression',
+        type: CallExpression,
         callee: { type: Literal, value: 'useFetch' },
-      } as unknown as TSESTree.Node;
+      } as TSESTree.Node;
 
       const destructuredFunctions = ['useFetch'];
 
@@ -1053,9 +1054,9 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return false if the function name is not in the list of destructured functions', () => {
       const node = {
-        type: 'CallExpression',
-        callee: { type: 'Identifier', name: 'fetchData' },
-      } as unknown as TSESTree.Node;
+        type: CallExpression,
+        callee: { type: Identifier, name: 'fetchData' },
+      } as TSESTree.Node;
 
       const destructuredFunctions = ['useFetch'];
 
@@ -1066,9 +1067,9 @@ describe('src/rules/helpers/astHelpers.ts', () => {
 
     it('should return true if the function name matches a destructured function', () => {
       const node = {
-        type: 'CallExpression',
-        callee: { type: 'Identifier', name: 'useData' },
-      } as unknown as TSESTree.Node;
+        type: CallExpression,
+        callee: { type: Identifier, name: 'useData' },
+      } as TSESTree.Node;
 
       const destructuredFunctions = ['useData'];
 

--- a/test/rules/helpers/astHelpers.spec.ts
+++ b/test/rules/helpers/astHelpers.spec.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  isNodeOfType,
   isIdentifier,
   isObjectPattern,
   isProperty,
@@ -7,101 +8,1073 @@ import {
   isVariableDeclarator,
   isMemberExpression,
   isAssignmentPattern,
+  isArrayExpression,
   addArgumentsToList,
   addReactiveVariables,
+  addToVariablesListFromCalleeWithArgument,
+  addDestructuredFunctionNames,
+  isArgumentOfFunction,
   isMatchingFunctionName,
+  isWatchArgument,
+  isFunctionCall,
+  getAncestorCallExpression,
+  isPropertyValue,
+  isFunctionArgument,
+  isObjectKey,
+  isOriginalDeclaration,
+  isNodeDestructuredFunction,
 } from '@/rules/helpers/astHelpers';
 import { TSESTree } from '@typescript-eslint/utils';
+import type { Node } from '@/rules/types/eslint';
+import * as astHelpers from '@/rules/helpers/astHelpers';
 
-describe('Node Type Checking Functions', () => {
-  it('should correctly identify an Identifier node', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.Identifier, name: 'myVar' } as TSESTree.Identifier;
-    expect(isIdentifier(node)).toBe(true);
-  });
+const {
+  Identifier,
+  ObjectPattern,
+  Property,
+  CallExpression,
+  VariableDeclarator,
+  MemberExpression,
+  AssignmentPattern,
+  ArrayExpression,
+  FunctionDeclaration,
+  BlockStatement,
+  ArrowFunctionExpression,
+  Literal,
+} = TSESTree.AST_NODE_TYPES;
 
-  it('should return false if node is not an Identifier', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.CallExpression } as TSESTree.CallExpression;
-    expect(isIdentifier(node)).toBe(false);
-  });
-
-  it('should correctly identify an ObjectPattern node', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.ObjectPattern, properties: [] } as unknown as TSESTree.ObjectPattern;
-    expect(isObjectPattern(node)).toBe(true);
-  });
-
-  it('should return false if node is not an ObjectPattern', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.Identifier } as TSESTree.Identifier;
-    expect(isObjectPattern(node)).toBe(false);
-  });
-
-  it('should correctly identify a Property node', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.Property } as TSESTree.Property;
-    expect(isProperty(node)).toBe(true);
-  });
-
-  it('should return false if node is not a Property', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.VariableDeclarator } as TSESTree.VariableDeclarator;
-    expect(isProperty(node)).toBe(false);
-  });
-
-  it('should correctly identify a CallExpression node', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.CallExpression } as TSESTree.CallExpression;
-    expect(isCallExpression(node)).toBe(true);
-  });
-
-  it('should correctly identify a VariableDeclarator node', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.VariableDeclarator } as TSESTree.VariableDeclarator;
-    expect(isVariableDeclarator(node)).toBe(true);
-  });
-
-  it('should correctly identify a MemberExpression node', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.MemberExpression } as TSESTree.MemberExpression;
-    expect(isMemberExpression(node)).toBe(true);
-  });
-
-  it('should correctly identify an AssignmentPattern node', () => {
-    const node = { type: TSESTree.AST_NODE_TYPES.AssignmentPattern } as TSESTree.AssignmentPattern;
-    expect(isAssignmentPattern(node)).toBe(true);
-  });
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
-describe('addArgumentsToList', () => {
-  it('should add function arguments to the list', () => {
-    const node = {
-      params: [
-        { type: TSESTree.AST_NODE_TYPES.Identifier, name: 'arg1' } as TSESTree.Identifier,
-        { type: TSESTree.AST_NODE_TYPES.Identifier, name: 'arg2' } as TSESTree.Identifier,
-      ],
-    } as TSESTree.FunctionDeclaration;
-    const list = ['existing'];
-    const result = addArgumentsToList(node, list);
-    expect(result).toEqual(['existing', 'arg1', 'arg2']);
-  });
-});
+describe('src/rules/helpers/astHelpers.ts', () => {
+  describe('isNodeOfType', () => {
+    it('should return true when node type matches the specified type', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isNodeOfType<TSESTree.Identifier>(node, Identifier)).toBe(true);
+    });
 
-describe('addReactiveVariables', () => {
-  it('should add reactive variable names to the list', () => {
-    const node = {
-      id: { type: TSESTree.AST_NODE_TYPES.Identifier, name: 'myReactiveVar' } as TSESTree.Identifier,
-      init: {
-        type: TSESTree.AST_NODE_TYPES.CallExpression,
-        callee: { type: TSESTree.AST_NODE_TYPES.Identifier, name: 'ref' },
-      },
-    } as TSESTree.VariableDeclarator;
-    const list = ['existingVar'];
-    const result = addReactiveVariables(node, list);
-    expect(result).toEqual(['existingVar', 'myReactiveVar']);
-  });
-});
+    it('should return false when node type does not match the specified type', () => {
+      const node: Node = { type: ObjectPattern } as TSESTree.ObjectPattern;
+      expect(isNodeOfType<TSESTree.Identifier>(node, Identifier)).toBe(false);
+    });
 
-describe('isMatchingFunctionName', () => {
-  it('should return true for matching function name', () => {
-    const result = isMatchingFunctionName('useSomething', ['useSomethingElse']);
-    expect(result).toBe(true);
+    it('should return false when node is undefined', () => {
+      const node = undefined;
+      expect(isNodeOfType<TSESTree.Identifier>(node, Identifier)).toBe(false);
+    });
+
+    it('should return false when node is null', () => {
+      const node = null;
+      expect(isNodeOfType<TSESTree.Identifier>(node, Identifier)).toBe(false);
+    });
   });
 
-  it('should return false for non-matching function name', () => {
-    const result = isMatchingFunctionName('doSomething', ['useSomethingElse']);
-    expect(result).toBe(false);
+  describe('isIdentifier', () => {
+    it('should return true when node is an Identifier', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isIdentifier(node)).toBe(true);
+    });
+
+    it('should return false when node is not an Identifier', () => {
+      const node = { type: CallExpression } as TSESTree.CallExpression;
+      expect(isIdentifier(node)).toBe(false);
+    });
+  });
+
+  describe('isObjectPattern', () => {
+    it('should return true when node is an ObjectPattern', () => {
+      const node = { type: ObjectPattern } as TSESTree.ObjectPattern;
+      expect(isObjectPattern(node)).toBe(true);
+    });
+
+    it('should return false when node is not an ObjectPattern', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isObjectPattern(node)).toBe(false);
+    });
+  });
+
+  describe('isProperty', () => {
+    it('should return true when node is a Property', () => {
+      const node = { type: Property } as TSESTree.Property;
+      expect(isProperty(node)).toBe(true);
+    });
+
+    it('should return false when node is not a Property', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isProperty(node)).toBe(false);
+    });
+  });
+
+  describe('isCallExpression', () => {
+    it('should return true when node is a CallExpression', () => {
+      const node = { type: CallExpression } as TSESTree.CallExpression;
+      expect(isCallExpression(node)).toBe(true);
+    });
+
+    it('should return false when node is not a CallExpression', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isCallExpression(node)).toBe(false);
+    });
+  });
+
+  describe('isVariableDeclarator', () => {
+    it('should return true when node is a VariableDeclarator', () => {
+      const node = { type: VariableDeclarator } as TSESTree.VariableDeclarator;
+      expect(isVariableDeclarator(node)).toBe(true);
+    });
+
+    it('should return false when node is not a VariableDeclarator', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isVariableDeclarator(node)).toBe(false);
+    });
+  });
+
+  describe('isMemberExpression', () => {
+    it('should return true when node is a MemberExpression', () => {
+      const node = { type: MemberExpression } as TSESTree.MemberExpression;
+      expect(isMemberExpression(node)).toBe(true);
+    });
+
+    it('should return false when node is not a MemberExpression', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isMemberExpression(node)).toBe(false);
+    });
+  });
+
+  describe('isAssignmentPattern', () => {
+    it('should return true when node is an AssignmentPattern', () => {
+      const node = { type: AssignmentPattern } as TSESTree.AssignmentPattern;
+      expect(isAssignmentPattern(node)).toBe(true);
+    });
+
+    it('should return false when node is not an AssignmentPattern', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isAssignmentPattern(node)).toBe(false);
+    });
+  });
+
+  describe('isArrayExpression', () => {
+    it('should return true when node is an ArrayExpression', () => {
+      const node = { type: ArrayExpression } as TSESTree.ArrayExpression;
+      expect(isArrayExpression(node)).toBe(true);
+    });
+
+    it('should return false when node is not an ArrayExpression', () => {
+      const node = { type: Identifier } as TSESTree.Identifier;
+      expect(isArrayExpression(node)).toBe(false);
+    });
+  });
+
+  describe('addArgumentsToList', () => {
+    it('should add identifier parameters to the list', () => {
+      const node = {
+        type: FunctionDeclaration,
+        id: null,
+        params: [{ type: Identifier, name: 'param1' }] as TSESTree.Identifier[],
+        body: { type: BlockStatement, body: [] } as unknown as TSESTree.BlockStatement,
+        generator: false,
+        async: false,
+        expression: false,
+      } as TSESTree.FunctionDeclaration;
+
+      const list: string[] = [];
+      const result = addArgumentsToList(node, list);
+      expect(result).toEqual(['param1']);
+    });
+
+    it('should return an empty list if there are no identifier parameters', () => {
+      const node = {
+        type: FunctionDeclaration,
+        id: null,
+        params: [{ type: ObjectPattern, properties: [] }] as unknown as TSESTree.ObjectPattern[],
+        body: { type: BlockStatement, body: [] } as unknown as TSESTree.BlockStatement,
+        generator: false,
+        async: false,
+        expression: false,
+      } as TSESTree.FunctionDeclaration;
+
+      const list: string[] = [];
+      const result = addArgumentsToList(node, list);
+      expect(result).toEqual([]);
+    });
+
+    it('should add parameters to an existing list', () => {
+      const node = {
+        type: ArrowFunctionExpression,
+        params: [{ type: Identifier, name: 'param2' }] as TSESTree.Identifier[],
+        body: { type: Identifier, name: 'test' } as TSESTree.Identifier,
+        expression: false,
+        async: false,
+      } as TSESTree.ArrowFunctionExpression;
+
+      const list = ['param1'];
+      const result = addArgumentsToList(node, list);
+      expect(result).toEqual(['param1', 'param2']);
+    });
+
+    it('should handle a function with no parameters', () => {
+      const node = {
+        type: FunctionDeclaration,
+        id: null,
+        params: [],
+        body: { type: BlockStatement, body: [] } as unknown as TSESTree.BlockStatement,
+        generator: false,
+        async: false,
+        expression: false,
+      } as unknown as TSESTree.FunctionDeclaration;
+
+      const list: string[] = [];
+      const result = addArgumentsToList(node, list);
+      expect(result).toEqual([]);
+    });
+
+    it('should ensure the original list is not mutated', () => {
+      const node = {
+        type: ArrowFunctionExpression,
+        params: [{ type: Identifier, name: 'param3' }] as TSESTree.Identifier[],
+        body: { type: Identifier, name: 'test' } as TSESTree.Identifier,
+        expression: false,
+        async: false,
+      } as TSESTree.ArrowFunctionExpression;
+
+      const list = ['param1', 'param2'];
+      const result = addArgumentsToList(node, list);
+      expect(list).toEqual(['param1', 'param2']);
+      expect(result).toEqual(['param1', 'param2', 'param3']);
+    });
+  });
+
+  describe('addReactiveVariables', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isFunctionCall').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+    });
+
+    it('should add variable to the list when it is a function call to a reactive function', () => {
+      const node = {
+        type: VariableDeclarator,
+        id: { type: Identifier, name: 'reactiveVar' },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'ref' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = [];
+      const result = addReactiveVariables(node, list);
+      expect(result).toEqual(['reactiveVar']);
+    });
+
+    it('should not add anything to the list when it is not a reactive function call', () => {
+      vi.spyOn(astHelpers, 'isFunctionCall').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: Identifier, name: 'nonReactiveVar' },
+        init: { type: Literal, value: 123 },
+      } as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addReactiveVariables(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list if node id is not an identifier', () => {
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: ObjectPattern, properties: [] },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'reactive' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addReactiveVariables(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list when the node init is not a function call', () => {
+      vi.spyOn(astHelpers, 'isFunctionCall').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: Identifier, name: 'someVar' },
+        init: { type: MemberExpression },
+      } as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addReactiveVariables(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+  });
+
+  describe('addToVariablesListFromCalleeWithArgument', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isFunctionCall').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isObjectPattern').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+    });
+
+    it('should add variable names to the list when the node is a reactive function call and id is an ObjectPattern', () => {
+      const node = {
+        type: VariableDeclarator,
+        id: {
+          type: ObjectPattern,
+          properties: [
+            { type: Property, value: { type: Identifier, name: 'variable1' } },
+            { type: Property, value: { type: Identifier, name: 'variable2' } },
+          ],
+        },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'ref' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = [];
+      const result = addToVariablesListFromCalleeWithArgument(node, list);
+      expect(result).toEqual(['variable1', 'variable2']);
+    });
+
+    it('should not add anything to the list if it is not a reactive function call', () => {
+      vi.spyOn(astHelpers, 'isFunctionCall').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: ObjectPattern, properties: [] },
+        init: { type: Literal, value: 123 },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addToVariablesListFromCalleeWithArgument(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list if node id is not an ObjectPattern', () => {
+      vi.spyOn(astHelpers, 'isObjectPattern').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: Identifier, name: 'someVar' },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'reactive' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addToVariablesListFromCalleeWithArgument(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list if the ObjectPattern has no Identifier properties', () => {
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: {
+          type: ObjectPattern,
+          properties: [{ type: Property, value: { type: Literal, value: 123 } }],
+        },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'ref' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addToVariablesListFromCalleeWithArgument(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+  });
+
+  describe('addDestructuredFunctionNames', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isObjectPattern').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isCallExpression').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isProperty').mockReturnValue(true);
+    });
+
+    it('should add function names to the list when destructuring functions starting with "use"', () => {
+      const node = {
+        type: VariableDeclarator,
+        id: {
+          type: ObjectPattern,
+          properties: [
+            { type: Property, key: { type: Identifier, name: 'useFetch' } },
+            { type: Property, key: { type: Identifier, name: 'useData' } },
+          ],
+        },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'useMyComposable' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = [];
+      const result = addDestructuredFunctionNames(node, list);
+      expect(result).toEqual(['useFetch', 'useData']);
+    });
+
+    it('should return the original list if node.id is not an ObjectPattern', () => {
+      vi.spyOn(astHelpers, 'isObjectPattern').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: Identifier, name: 'someVar' },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'useMyComposable' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addDestructuredFunctionNames(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list if node.init is not a CallExpression', () => {
+      vi.spyOn(astHelpers, 'isCallExpression').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: ObjectPattern, properties: [] },
+        init: { type: Literal, value: 123 },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addDestructuredFunctionNames(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list if node.init.callee is not an Identifier', () => {
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: { type: ObjectPattern, properties: [] },
+        init: { type: CallExpression, callee: { type: Literal, value: '123' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addDestructuredFunctionNames(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list if the function name does not match COMPOSABLES_FUNCTION_PATTERN', () => {
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+
+      const node = {
+        type: VariableDeclarator,
+        id: {
+          type: ObjectPattern,
+          properties: [{ type: Property, key: { type: Identifier, name: 'fetchData' } }],
+        },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'fetchMyComposable' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+
+      const result = addDestructuredFunctionNames(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+
+    it('should return the original list if property.key is not an Identifier', () => {
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
+
+      const node = {
+        type: VariableDeclarator,
+        id: {
+          type: ObjectPattern,
+          properties: [{ type: Property, key: { type: Literal, value: 123 } }],
+        },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'useMyComposable' }, arguments: [] },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const list: string[] = ['existingVar'];
+      const result = addDestructuredFunctionNames(node, list);
+      expect(result).toEqual(['existingVar']);
+    });
+  });
+
+  describe('isArgumentOfFunction', () => {
+    beforeEach(() => {
+      const callExpression = {
+        type: CallExpression,
+        callee: { type: Identifier, name: 'someFunction' },
+        arguments: [{ type: Identifier, name: 'arg1' }],
+      } as unknown as TSESTree.CallExpression;
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isMatchingFunctionName').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should return true if the node is an argument of the specified function', () => {
+      const node = {
+        type: Identifier,
+        name: 'arg1',
+        parent: {
+          type: CallExpression,
+          callee: { type: Identifier, name: 'someFunction' },
+          arguments: [{ type: Identifier, name: 'arg1' }],
+        },
+      } as TSESTree.Identifier;
+
+      const ignoredFunctionNames = ['someFunction'];
+
+      const result = isArgumentOfFunction(node, ignoredFunctionNames);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the node is not an argument of the specified function', () => {
+      const node = {
+        type: Identifier,
+        name: 'arg2',
+        parent: {
+          type: CallExpression,
+          callee: { type: Identifier, name: 'someFunction' },
+          arguments: [],
+        },
+      } as unknown as TSESTree.Identifier;
+
+      const ignoredFunctionNames = ['someFunction'];
+
+      const result = isArgumentOfFunction(node, ignoredFunctionNames);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the node is not an argument of the specified function', () => {
+      const node = { type: Identifier, name: 'arg2' } as TSESTree.Identifier;
+
+      const ignoredFunctionNames = ['someFunction'];
+      const result = isArgumentOfFunction(node, ignoredFunctionNames);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the callExpression.callee is not an Identifier', () => {
+      const node = { type: Identifier, name: 'arg3' } as TSESTree.Identifier;
+      const callExpression = {
+        type: CallExpression,
+        callee: { type: Literal, value: 'nonIdentifier' },
+        arguments: [node],
+      } as unknown as TSESTree.CallExpression;
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
+
+      const ignoredFunctionNames = ['someFunction'];
+      const result = isArgumentOfFunction(node, ignoredFunctionNames);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the function name does not match any ignored function names', () => {
+      const node = { type: Identifier, name: 'arg4' } as TSESTree.Identifier;
+      const callExpression = {
+        type: CallExpression,
+        callee: { type: Identifier, name: 'differentFunction' },
+        arguments: [node],
+      } as unknown as TSESTree.CallExpression;
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isMatchingFunctionName').mockReturnValue(false);
+
+      const ignoredFunctionNames = ['someFunction'];
+      const result = isArgumentOfFunction(node, ignoredFunctionNames);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isMatchingFunctionName', () => {
+    it('should return true if the function name matches the composables pattern', () => {
+      const result = isMatchingFunctionName('useFetch', []);
+      expect(result).toBe(true);
+    });
+
+    it('should return true if the function name is in the ignored function names list', () => {
+      const result = isMatchingFunctionName('myFunction', ['myFunction']);
+      expect(result).toBe(true);
+    });
+
+    it('should return true if the function name matches both the composables pattern and is in ignored function names', () => {
+      const result = isMatchingFunctionName('useFetch', ['useFetch']);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the function name does not match the pattern or ignored list', () => {
+      const result = isMatchingFunctionName('fetchData', ['otherFunction']);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isWatchArgument', () => {
+    let node: TSESTree.Identifier;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      node = {
+        type: Identifier,
+        name: 'arg1',
+        parent: {
+          type: CallExpression,
+          callee: { type: Identifier, name: 'watch' },
+          arguments: [],
+        },
+      } as unknown as TSESTree.Identifier;
+    });
+
+    it('should return true if the node is the first argument of the "watch" function', () => {
+      const callExpression = node.parent as TSESTree.CallExpression;
+      callExpression.arguments.push(node);
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+
+      const result = isWatchArgument(node);
+      expect(result).toBe(true);
+    });
+
+    it('should return true if the node is inside an array expression as the first argument of the "watch" function', () => {
+      const arrayExpression = {
+        type: ArrayExpression,
+        elements: [node],
+      } as unknown as TSESTree.ArrayExpression;
+
+      const callExpression = node.parent as TSESTree.CallExpression;
+      callExpression.arguments.push(arrayExpression);
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isArrayExpression').mockReturnValue(true);
+
+      const result = isWatchArgument(node);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the node is not an argument of the "watch" function', () => {
+      const otherNode = {
+        type: Identifier,
+        name: 'otherArg',
+      } as TSESTree.Identifier;
+
+      const callExpression = node.parent as TSESTree.CallExpression;
+      callExpression.arguments.push(otherNode);
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+
+      const result = isWatchArgument(node);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the callee is not "watch"', () => {
+      const callExpression = {
+        ...node.parent,
+        callee: { type: Identifier, name: 'notWatch' },
+      } as unknown as TSESTree.CallExpression;
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+
+      const result = isWatchArgument(node);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the first argument is not an identifier or in an array expression', () => {
+      const LiteralNode = {
+        type: Literal,
+        value: 'someValue',
+      } as TSESTree.Literal;
+
+      const callExpression = node.parent as TSESTree.CallExpression;
+      callExpression.arguments.push(LiteralNode);
+
+      vi.spyOn(astHelpers, 'getAncestorCallExpression').mockReturnValue(callExpression);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isArrayExpression').mockReturnValue(false);
+
+      const result = isWatchArgument(node);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isFunctionCall', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isCallExpression').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return true if node.init is a call expression and callee is in the function names list', () => {
+      const node = {
+        type: 'VariableDeclarator',
+        init: {
+          type: 'CallExpression',
+          callee: { type: 'Identifier', name: 'myFunction' },
+        },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const functionNames = ['myFunction'];
+      const result = isFunctionCall(node, functionNames);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if node.init is not a call expression', () => {
+      vi.spyOn(astHelpers, 'isCallExpression').mockReturnValue(false);
+
+      const node = {
+        type: 'VariableDeclarator',
+        init: {
+          type: Literal,
+          value: 'someValue',
+        },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const functionNames = ['myFunction'];
+      const result = isFunctionCall(node, functionNames);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if node.init.callee is not an identifier', () => {
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
+
+      const node = {
+        type: 'VariableDeclarator',
+        init: {
+          type: 'CallExpression',
+          callee: { type: Literal, value: 'someValue' },
+        },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const functionNames = ['myFunction'];
+      const result = isFunctionCall(node, functionNames);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if callee name is not in the function names list', () => {
+      const node = {
+        type: 'VariableDeclarator',
+        init: {
+          type: 'CallExpression',
+          callee: { type: 'Identifier', name: 'otherFunction' },
+        },
+      } as unknown as TSESTree.VariableDeclarator;
+
+      const functionNames = ['myFunction'];
+      const result = isFunctionCall(node, functionNames);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getAncestorCallExpression', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isCallExpression').mockReturnValue(true);
+    });
+
+    it('should return the first CallExpression node when found', () => {
+      const node = {
+        type: 'Identifier',
+        parent: {
+          type: 'ExpressionStatement',
+          parent: {
+            type: 'CallExpression',
+            callee: { type: 'Identifier', name: 'myFunction' },
+          },
+        },
+      } as unknown as TSESTree.Node;
+
+      const result = getAncestorCallExpression(node);
+      expect(result).toEqual({
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'myFunction' },
+      });
+    });
+
+    it('should return null if no CallExpression is found', () => {
+      const node = {
+        type: 'Identifier',
+        parent: {
+          type: 'ExpressionStatement',
+          parent: {
+            type: 'BlockStatement',
+          },
+        },
+      } as unknown as TSESTree.Node;
+
+      const result = getAncestorCallExpression(node);
+      expect(result).toBeNull();
+    });
+
+    it('should return null if the node has no parent', () => {
+      const node = {
+        type: 'Identifier',
+        parent: null,
+      } as unknown as TSESTree.Node;
+
+      const result = getAncestorCallExpression(node);
+      expect(result).toBeNull();
+    });
+
+    it('should return null if there are no ancestors', () => {
+      const node = {
+        type: 'Identifier',
+      } as unknown as TSESTree.Node;
+
+      const result = getAncestorCallExpression(node);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('isPropertyValue', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isMemberExpression').mockImplementation((node) => node?.type === 'MemberExpression');
+      vi.spyOn(astHelpers, 'isIdentifier').mockImplementation((node) => node?.type === 'Identifier');
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return true when the node is a MemberExpression with property name "value"', () => {
+      const node = {
+        type: 'MemberExpression',
+        object: { type: 'Identifier', name: 'refValue' },
+        property: { type: 'Identifier', name: 'value' },
+      } as unknown as TSESTree.Node;
+
+      const result = isPropertyValue(node);
+      expect(result).toBe(true);
+    });
+
+    it('should return false when the node is not a MemberExpression', () => {
+      const node = {
+        type: Literal,
+        value: 123,
+      } as unknown as TSESTree.Node;
+
+      const result = isPropertyValue(node);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when the property is not an Identifier', () => {
+      const node = {
+        type: 'MemberExpression',
+        object: { type: 'Identifier', name: 'refValue' },
+        property: { type: Literal, value: 'value' },
+      } as unknown as TSESTree.Node;
+
+      const result = isPropertyValue(node);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when the property name is not "value"', () => {
+      const node = {
+        type: 'MemberExpression',
+        object: { type: 'Identifier', name: 'refValue' },
+        property: { type: 'Identifier', name: 'notValue' },
+      } as unknown as TSESTree.Node;
+
+      const result = isPropertyValue(node);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isFunctionArgument', () => {
+    it('should return true if the node name is in the function arguments list', () => {
+      const node = { type: 'Identifier', name: 'arg1' } as TSESTree.Identifier;
+      const functionArguments = ['arg1', 'arg2'];
+
+      const result = isFunctionArgument(node, functionArguments);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the node name is not in the function arguments list', () => {
+      const node = { type: 'Identifier', name: 'arg3' } as TSESTree.Identifier;
+      const functionArguments = ['arg1', 'arg2'];
+
+      const result = isFunctionArgument(node, functionArguments);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the function arguments list is empty', () => {
+      const node = { type: 'Identifier', name: 'arg1' } as TSESTree.Identifier;
+      const functionArguments: string[] = [];
+
+      const result = isFunctionArgument(node, functionArguments);
+      expect(result).toBe(false);
+    });
+
+    it('should return true if the node name matches exactly in the function arguments list', () => {
+      const node = { type: 'Identifier', name: 'arg' } as TSESTree.Identifier;
+      const functionArguments = ['arg'];
+
+      const result = isFunctionArgument(node, functionArguments);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the node name partially matches any of the function arguments', () => {
+      const node = { type: 'Identifier', name: 'arg' } as TSESTree.Identifier;
+      const functionArguments = ['argument'];
+
+      const result = isFunctionArgument(node, functionArguments);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isObjectKey', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isProperty').mockReturnValue(true);
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return true if the node is a property and the key matches the identifier name', () => {
+      const node = {
+        type: 'Property',
+        key: { type: 'Identifier', name: 'key1' },
+      } as TSESTree.Property;
+
+      const identifierNode = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
+
+      const result = isObjectKey(node, identifierNode);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the node is not a property', () => {
+      vi.spyOn(astHelpers, 'isProperty').mockReturnValue(false);
+
+      const node = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
+      const identifierNode = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
+
+      const result = isObjectKey(node, identifierNode);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the node key is not an identifier', () => {
+      vi.spyOn(astHelpers, 'isIdentifier').mockReturnValue(false);
+
+      const node = {
+        type: 'Property',
+        key: { type: Literal, value: 'key1' },
+      } as unknown as TSESTree.Property;
+
+      const identifierNode = { type: 'Identifier', name: 'key1' } as TSESTree.Identifier;
+
+      const result = isObjectKey(node, identifierNode);
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the node key does not match the identifier name', () => {
+      const node = {
+        type: 'Property',
+        key: { type: 'Identifier', name: 'key1' },
+      } as TSESTree.Property;
+
+      const identifierNode = { type: 'Identifier', name: 'key2' } as TSESTree.Identifier;
+
+      const result = isObjectKey(node, identifierNode);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isOriginalDeclaration', () => {
+    beforeEach(() => {
+      vi.spyOn(astHelpers, 'isMemberExpression').mockReturnValue(false);
+      vi.spyOn(astHelpers, 'isProperty').mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return true if the node is a MemberExpression', () => {
+      vi.spyOn(astHelpers, 'isMemberExpression').mockReturnValue(true);
+
+      const node = { type: 'MemberExpression' } as TSESTree.MemberExpression;
+
+      const result = isOriginalDeclaration(node);
+      expect(result).toBe(true);
+    });
+
+    it('should return true if the node is a Property', () => {
+      vi.spyOn(astHelpers, 'isProperty').mockReturnValue(true);
+
+      const node = { type: 'Property' } as TSESTree.Property;
+
+      const result = isOriginalDeclaration(node);
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the node is neither a MemberExpression nor a Property', () => {
+      vi.spyOn(astHelpers, 'isMemberExpression').mockReturnValue(false);
+      vi.spyOn(astHelpers, 'isProperty').mockReturnValue(false);
+
+      const node = { type: 'Identifier' } as TSESTree.Identifier;
+
+      const result = isOriginalDeclaration(node);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('isNodeDestructuredFunction', () => {
+    it('should return true if the node is a destructured function call', () => {
+      const node = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'useFetch' },
+      } as unknown as TSESTree.Node;
+
+      const destructuredFunctions = ['useFetch'];
+
+      const result = isNodeDestructuredFunction(node, destructuredFunctions);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if the node is not a CallExpression', () => {
+      const node = {
+        type: 'Identifier',
+        callee: { type: 'Identifier', name: 'useFetch' },
+      } as unknown as TSESTree.Node;
+
+      const destructuredFunctions = ['useFetch'];
+
+      const result = isNodeDestructuredFunction(node, destructuredFunctions);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the callee is not an Identifier', () => {
+      const node = {
+        type: 'CallExpression',
+        callee: { type: Literal, value: 'useFetch' },
+      } as unknown as TSESTree.Node;
+
+      const destructuredFunctions = ['useFetch'];
+
+      const result = isNodeDestructuredFunction(node, destructuredFunctions);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false if the function name is not in the list of destructured functions', () => {
+      const node = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'fetchData' },
+      } as unknown as TSESTree.Node;
+
+      const destructuredFunctions = ['useFetch'];
+
+      const result = isNodeDestructuredFunction(node, destructuredFunctions);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true if the function name matches a destructured function', () => {
+      const node = {
+        type: 'CallExpression',
+        callee: { type: 'Identifier', name: 'useData' },
+      } as unknown as TSESTree.Node;
+
+      const destructuredFunctions = ['useData'];
+
+      const result = isNodeDestructuredFunction(node, destructuredFunctions);
+
+      expect(result).toBe(true);
+    });
   });
 });

--- a/test/rules/helpers/astHelpers.spec.ts
+++ b/test/rules/helpers/astHelpers.spec.ts
@@ -50,6 +50,57 @@ afterEach(() => {
 
 describe('src/rules/helpers/astHelpers.ts', () => {
   describe('isNodeOfType', () => {
+    const testCases = [
+      {
+        func: isIdentifier,
+        name: 'isIdentifier',
+        validType: Identifier,
+        invalidType: CallExpression,
+      },
+      {
+        func: isObjectPattern,
+        name: 'isObjectPattern',
+        validType: ObjectPattern,
+        invalidType: Identifier,
+      },
+      {
+        func: isProperty,
+        name: 'isProperty',
+        validType: Property,
+        invalidType: Identifier,
+      },
+      {
+        func: isCallExpression,
+        name: 'isCallExpression',
+        validType: CallExpression,
+        invalidType: Identifier,
+      },
+      {
+        func: isVariableDeclarator,
+        name: 'isVariableDeclarator',
+        validType: VariableDeclarator,
+        invalidType: Identifier,
+      },
+      {
+        func: isMemberExpression,
+        name: 'isMemberExpression',
+        validType: MemberExpression,
+        invalidType: Identifier,
+      },
+      {
+        func: isAssignmentPattern,
+        name: 'isAssignmentPattern',
+        validType: AssignmentPattern,
+        invalidType: Identifier,
+      },
+      {
+        func: isArrayExpression,
+        name: 'isArrayExpression',
+        validType: ArrayExpression,
+        invalidType: Identifier,
+      },
+    ];
+
     it('should return true when node type matches the specified type', () => {
       const node = { type: Identifier } as TSESTree.Identifier;
       expect(isNodeOfType<TSESTree.Identifier>(node, Identifier)).toBe(true);
@@ -69,101 +120,19 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       const node = null;
       expect(isNodeOfType<TSESTree.Identifier>(node, Identifier)).toBe(false);
     });
-  });
 
-  describe('isIdentifier', () => {
-    it('should return true when node is an Identifier', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isIdentifier(node)).toBe(true);
-    });
+    testCases.forEach(({ func, name, validType, invalidType }) => {
+      describe(name, () => {
+        it(`should return true when node is a ${name}`, () => {
+          const node = { type: validType } as TSESTree.Node;
+          expect(func(node)).toBe(true);
+        });
 
-    it('should return false when node is not an Identifier', () => {
-      const node = { type: CallExpression } as TSESTree.CallExpression;
-      expect(isIdentifier(node)).toBe(false);
-    });
-  });
-
-  describe('isObjectPattern', () => {
-    it('should return true when node is an ObjectPattern', () => {
-      const node = { type: ObjectPattern } as TSESTree.ObjectPattern;
-      expect(isObjectPattern(node)).toBe(true);
-    });
-
-    it('should return false when node is not an ObjectPattern', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isObjectPattern(node)).toBe(false);
-    });
-  });
-
-  describe('isProperty', () => {
-    it('should return true when node is a Property', () => {
-      const node = { type: Property } as TSESTree.Property;
-      expect(isProperty(node)).toBe(true);
-    });
-
-    it('should return false when node is not a Property', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isProperty(node)).toBe(false);
-    });
-  });
-
-  describe('isCallExpression', () => {
-    it('should return true when node is a CallExpression', () => {
-      const node = { type: CallExpression } as TSESTree.CallExpression;
-      expect(isCallExpression(node)).toBe(true);
-    });
-
-    it('should return false when node is not a CallExpression', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isCallExpression(node)).toBe(false);
-    });
-  });
-
-  describe('isVariableDeclarator', () => {
-    it('should return true when node is a VariableDeclarator', () => {
-      const node = { type: VariableDeclarator } as TSESTree.VariableDeclarator;
-      expect(isVariableDeclarator(node)).toBe(true);
-    });
-
-    it('should return false when node is not a VariableDeclarator', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isVariableDeclarator(node)).toBe(false);
-    });
-  });
-
-  describe('isMemberExpression', () => {
-    it('should return true when node is a MemberExpression', () => {
-      const node = { type: MemberExpression } as TSESTree.MemberExpression;
-      expect(isMemberExpression(node)).toBe(true);
-    });
-
-    it('should return false when node is not a MemberExpression', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isMemberExpression(node)).toBe(false);
-    });
-  });
-
-  describe('isAssignmentPattern', () => {
-    it('should return true when node is an AssignmentPattern', () => {
-      const node = { type: AssignmentPattern } as TSESTree.AssignmentPattern;
-      expect(isAssignmentPattern(node)).toBe(true);
-    });
-
-    it('should return false when node is not an AssignmentPattern', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isAssignmentPattern(node)).toBe(false);
-    });
-  });
-
-  describe('isArrayExpression', () => {
-    it('should return true when node is an ArrayExpression', () => {
-      const node = { type: ArrayExpression } as TSESTree.ArrayExpression;
-      expect(isArrayExpression(node)).toBe(true);
-    });
-
-    it('should return false when node is not an ArrayExpression', () => {
-      const node = { type: Identifier } as TSESTree.Identifier;
-      expect(isArrayExpression(node)).toBe(false);
+        it(`should return false when node is not a ${name}`, () => {
+          const node = { type: invalidType } as TSESTree.Node;
+          expect(func(node)).toBe(false);
+        });
+      });
     });
   });
 
@@ -171,12 +140,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
     it('should add identifier parameters to the list', () => {
       const node = {
         type: FunctionDeclaration,
-        id: null,
         params: [{ type: Identifier, name: 'param1' }] as TSESTree.Identifier[],
-        body: { type: BlockStatement, body: [] } as unknown as TSESTree.BlockStatement,
-        generator: false,
-        async: false,
-        expression: false,
       } as TSESTree.FunctionDeclaration;
 
       const list: string[] = [];
@@ -256,7 +220,7 @@ describe('src/rules/helpers/astHelpers.ts', () => {
       const node = {
         type: VariableDeclarator,
         id: { type: Identifier, name: 'reactiveVar' },
-        init: { type: CallExpression, callee: { type: Identifier, name: 'ref' }, arguments: [] },
+        init: { type: CallExpression, callee: { type: Identifier, name: 'ref' } },
       } as unknown as TSESTree.VariableDeclarator;
 
       const list: string[] = [];

--- a/test/rules/utils/arrayUtils.spec.ts
+++ b/test/rules/utils/arrayUtils.spec.ts
@@ -2,39 +2,41 @@ import { describe, it, expect } from 'vitest';
 import { addToList } from '@/rules/utils/arrayUtils';
 
 describe('src/rules/utils/arrayUtils.ts', () => {
-  it('adds items to an empty list', () => {
-    const items = ['apple', 'banana'];
-    const list: string[] = [];
-    const result = addToList(items, list);
-    expect(result).toEqual(['apple', 'banana']);
-  });
+  describe('addToList', () => {
+    it('adds items to an empty list', () => {
+      const items = ['apple', 'banana'];
+      const list: string[] = [];
+      const result = addToList(items, list);
+      expect(result).toEqual(['apple', 'banana']);
+    });
 
-  it('adds items to an existing list', () => {
-    const items = ['orange', 'grape'];
-    const list = ['apple', 'banana'];
-    const result = addToList(items, list);
-    expect(result).toEqual(['apple', 'banana', 'orange', 'grape']);
-  });
+    it('adds items to an existing list', () => {
+      const items = ['orange', 'grape'];
+      const list = ['apple', 'banana'];
+      const result = addToList(items, list);
+      expect(result).toEqual(['apple', 'banana', 'orange', 'grape']);
+    });
 
-  it('ensures the original list is not mutated', () => {
-    const items = ['kiwi'];
-    const list = ['apple'];
-    const result = addToList(items, list);
-    expect(list).toEqual(['apple']);
-    expect(result).toEqual(['apple', 'kiwi']);
-  });
+    it('ensures the original list is not mutated', () => {
+      const items = ['kiwi'];
+      const list = ['apple'];
+      const result = addToList(items, list);
+      expect(list).toEqual(['apple']);
+      expect(result).toEqual(['apple', 'kiwi']);
+    });
 
-  it('handles an empty items array', () => {
-    const items: string[] = [];
-    const list = ['apple', 'banana'];
-    const result = addToList(items, list);
-    expect(result).toEqual(['apple', 'banana']);
-  });
+    it('handles an empty items array', () => {
+      const items: string[] = [];
+      const list = ['apple', 'banana'];
+      const result = addToList(items, list);
+      expect(result).toEqual(['apple', 'banana']);
+    });
 
-  it('handles both items and list being empty', () => {
-    const items: string[] = [];
-    const list: string[] = [];
-    const result = addToList(items, list);
-    expect(result).toEqual([]);
+    it('handles both items and list being empty', () => {
+      const items: string[] = [];
+      const list: string[] = [];
+      const result = addToList(items, list);
+      expect(result).toEqual([]);
+    });
   });
 });


### PR DESCRIPTION
```bash
 ✓ test/rules/helpers/astHelpers.spec.ts (78)
   ✓ src/rules/helpers/astHelpers.ts (78)
     ✓ isNodeOfType (20)
       ✓ should return true when node type matches the specified type
       ✓ should return false when node type does not match the specified type
       ✓ should return false when node is undefined
       ✓ should return false when node is null
       ✓ isIdentifier (2)
         ✓ should return true when node is a isIdentifier
         ✓ should return false when node is not a isIdentifier
       ✓ isObjectPattern (2)
         ✓ should return true when node is a isObjectPattern
         ✓ should return false when node is not a isObjectPattern
       ✓ isProperty (2)
         ✓ should return true when node is a isProperty
         ✓ should return false when node is not a isProperty
       ✓ isCallExpression (2)
         ✓ should return true when node is a isCallExpression
         ✓ should return false when node is not a isCallExpression
       ✓ isVariableDeclarator (2)
         ✓ should return true when node is a isVariableDeclarator
         ✓ should return false when node is not a isVariableDeclarator
       ✓ isMemberExpression (2)
         ✓ should return true when node is a isMemberExpression
         ✓ should return false when node is not a isMemberExpression
       ✓ isAssignmentPattern (2)
         ✓ should return true when node is a isAssignmentPattern
         ✓ should return false when node is not a isAssignmentPattern
       ✓ isArrayExpression (2)
         ✓ should return true when node is a isArrayExpression
         ✓ should return false when node is not a isArrayExpression
     ✓ addArgumentsToList (5)
       ✓ should add identifier parameters to the list
       ✓ should return an empty list if there are no identifier parameters
       ✓ should add parameters to an existing list
       ✓ should handle a function with no parameters
       ✓ should ensure the original list is not mutated
     ✓ addReactiveVariables (2)
       ✓ should add variable to the list when it is a function call to a reactive function
       ✓ should not add anything to the list when it is not a reactive function call
     ✓ addToVariablesListFromCalleeWithArgument (4)
       ✓ should add variable names to the list when the node is a reactive function call and id is an ObjectPattern
       ✓ should not add anything to the list if it is not a reactive function call
       ✓ should return the original list if node id is not an ObjectPattern
       ✓ should return the original list if the ObjectPattern has no Identifier properties
     ✓ addDestructuredFunctionNames (4)
       ✓ should add function names to the list when destructuring functions starting with "use"
       ✓ should return the original list if node.id is not an ObjectPattern
       ✓ should return the original list if node.init is not a CallExpression
       ✓ should return the original list if node.init.callee is not an Identifier
     ✓ isArgumentOfFunction (4)
       ✓ should return true if the node is an argument of the specified function
       ✓ should return false if the node is not an argument of the specified function
       ✓ should return false if the callExpression.callee is not an Identifier
       ✓ should return false if the function name does not match any ignored function names
     ✓ isMatchingFunctionName (3)
       ✓ should return true for function name "useFetch"
       ✓ should return true for function name "myFunction"
       ✓ should return false for function name "fetchData"
     ✓ isWatchArgument (7)
       ✓ should return true if the node is the first argument of the "watch" function
       ✓ should return false if the node is not an argument of the "watch" function
       ✓ should return false if the callExpression.callee is not an identifier
       ✓ should return false if the callExpression.callee is not the "watch" function
       ✓ should return false if the callee.name is not "watch"
       ✓ should return true if the node is part of an array expression in the "watch" function arguments
       ✓ should return false if the node is not part of the array expression in the "watch" function arguments
     ✓ isFunctionCall (4)
       ✓ should return true if node.init is a call expression and callee is in the function names list
       ✓ should return false if node.init is not a call expression
       ✓ should return false if node.init.callee is not an identifier
       ✓ should return false if callee name is not in the function names list
     ✓ getAncestorCallExpression (3)
       ✓ should return the first CallExpression node when found
       ✓ should return null if no CallExpression is found
       ✓ should return null if the node has no parent
     ✓ isPropertyValue (4)
       ✓ should return true when the node is a MemberExpression with property name "value"
       ✓ should return false when the node is not a MemberExpression
       ✓ should return false when the property is not an Identifier
       ✓ should return false when the property name is not "value"
     ✓ isFunctionArgument (3)
       ✓ should return true if the node name is in the function arguments list
       ✓ should return false if the node name is not in the function arguments list
       ✓ should return false if the function arguments list is empty
     ✓ isObjectKey (4)
       ✓ should return true if the node is a property and the key matches the identifier name
       ✓ should return false if the node is not a property
       ✓ should return false if the node key is not an identifier
       ✓ should return false if the node key does not match the identifier name
     ✓ isOriginalDeclaration (3)
       ✓ should return true if the node is a MemberExpression
       ✓ should return true if the node is a Property
       ✓ should return false if the node is neither a MemberExpression nor a Property
     ✓ isNodeDestructuredFunction (5)
       ✓ should return true if the node is a destructured function call
       ✓ should return false if the node is not a CallExpression
       ✓ should return false if the callee is not an Identifier
       ✓ should return false if the function name is not in the list of destructured functions
       ✓ should return true if the function name matches a destructured function
     ✓ isDestructuredFunctionArgument (3)
       ✓ should return true if the parent is a destructured function
       ✓ should return true if the grandParent is a destructured function
       ✓ should return false if neither parent nor grandParent is a destructured function

 Test Files  1 passed (1)
      Tests  78 passed (78)
   Start at  18:04:15
   Duration  160ms

 % Coverage report from v8
----------------|---------|----------|---------|---------|-------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------------|---------|----------|---------|---------|-------------------
All files       |     100 |      100 |     100 |     100 |                   
 constants      |     100 |      100 |     100 |     100 |                   
  constant.ts   |     100 |      100 |     100 |     100 |                   
 helpers        |     100 |      100 |     100 |     100 |                   
  astHelpers.ts |     100 |      100 |     100 |     100 |                   
 utils          |     100 |      100 |     100 |     100 |                   
  arrayUtils.ts |     100 |      100 |     100 |     100 |                   
----------------|---------|----------|---------|---------|-------------------
```

---

close #13 