### PR TITLE
fix: add support for aliased destructuring in shouldSuppressWarning

### DIFF
--- a/src/rules/helpers/function-checks.ts
+++ b/src/rules/helpers/function-checks.ts
@@ -6,6 +6,7 @@ import {
   isIdentifier,
   isMemberExpression,
   isObjectExpression,
+  isObjectPattern,
   isProperty,
   isVariableDeclarator,
 } from './ast-helpers';
@@ -99,8 +100,13 @@ export const shouldSuppressWarning = (
   composableFunctions: ReadonlyArray<string>,
   ignoredFunctionNames: ReadonlyArray<string>,
 ): boolean => {
+  const isAliasedDestructuring = isProperty(parent) && parent.value === node && isObjectPattern(parent.parent);
+
   const isInDeclarationContext =
-    isVariableDeclarator(parent) || isArrayPattern(parent) || (parent.parent && isPropertyValue(parent));
+    isVariableDeclarator(parent) ||
+    isArrayPattern(parent) ||
+    (parent.parent && isPropertyValue(parent)) ||
+    isAliasedDestructuring;
 
   const isPropertyAccess =
     (isMemberExpression(parent) && isIdentifier(parent.property) && parent.property.name === 'value') ||


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved warning suppression to better handle aliased destructuring scenarios, reducing unnecessary alerts in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->